### PR TITLE
Add logo in the centre

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -40,41 +40,42 @@
 
   <link rel="stylesheet" href="/css/main.css" />
 </head>
-<nav class="navbar navbar-expand-md navbar-light fixed-top bg-light">
-  {% assign default_paths = site.pages | map: "path" %} {% assign page_paths =
-  site.header_pages | default: default_paths %}
-  <a class="navbar-brand" href="/">
-    <!-- <img
-      src="logo.svg"
-      width="30"
-      height="30"
-      class="d-inline-block align-top"
-      alt=""
-    /> -->
-    {{ site.title | escape }}
-  </a>
-  <button
-    class="navbar-toggler"
-    type="button"
-    data-toggle="collapse"
-    data-target="#navbarsExampleDefault"
-    aria-controls="navbarsExampleDefault"
-    aria-expanded="false"
-    aria-label="Toggle navigation"
-  >
-    <span class="navbar-toggler-icon"></span>
-  </button>
+<nav class="navbar navbar-expand-md navbar-light fixed-top bg-light box-shadow">
+  <div class="container">
+    {% assign default_paths = site.pages | map: "path" %} {% assign page_paths =
+    site.header_pages | default: default_paths %}
+    <a class="navbar-brand" style="color:#2045d7; " href="/">
+      <h3>
+        {{ site.title | escape }}
+      </h3>
+    </a>
 
-  <div class="collapse navbar-collapse" id="navbarsExampleDefault">
-    <ul class="navbar-nav ml-auto">
-      {% for path in page_paths %} {% assign my_page = site.pages | where:
-      "path", path | first %} {% if my_page.title %}
-      <li class="nav-item">
-        <a class="nav-link" href="{{ my_page.url | relative_url }}">{{
-          my_page.title | escape
-        }}</a>
-      </li>
-      {% endif %} {% endfor %}
-    </ul>
+    <div class="collapse navbar-collapse">
+      <img src="/logo.svg" height="70px" class="navbar-nav ml-auto" alt="" />
+    </div>
+    <button
+      class="navbar-toggler"
+      type="button"
+      data-toggle="collapse"
+      data-target="#navbarsExampleDefault"
+      aria-controls="navbarsExampleDefault"
+      aria-expanded="false"
+      aria-label="Toggle navigation"
+    >
+      <span class="navbar-toggler-icon"></span>
+    </button>
+
+    <div class="collapse navbar-collapse" id="navbarsExampleDefault">
+      <ul class="navbar-nav ml-auto">
+        {% for path in page_paths %} {% assign my_page = site.pages | where:
+        "path", path | first %} {% if my_page.title %}
+        <li class="nav-item">
+          <a class="nav-link" href="{{ my_page.url | relative_url }}">{{
+            my_page.title | escape
+          }}</a>
+        </li>
+        {% endif %} {% endfor %}
+      </ul>
+    </div>
   </div>
 </nav>

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html lang="en">
+  {% include header.html %}
+  <body>
+    <main role="main">
+      <div style="background-color:#ffffff" class="container">
+        <div class="row">
+          <div class="col-sm-12">
+            <a
+              style="color:#000000"
+              class="display-4 font-weight-bold"
+              href="{{ page.url }}"
+            >
+              {{ page.title }}
+            </a>
+            <p class="lead font-weight-bold">
+              <span></span>
+            </p>
+          </div>
+        </div>
+        {{ content }}
+      </div>
+    </main>
+    {% include footer.html %}
+  </body>
+</html>

--- a/css/custom/_variables.scss
+++ b/css/custom/_variables.scss
@@ -1,1 +1,1 @@
-$primary: #003366;
+$primary: #2045d7;

--- a/css/main.scss
+++ b/css/main.scss
@@ -4,7 +4,11 @@
 @import "bootstrap/bootstrap";
 
 body {
-  padding-top: 4rem;
+  padding-top: 6rem;
+}
+
+.box-shadow {
+  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.05);
 }
 
 footer {
@@ -14,16 +18,6 @@ footer {
 
 footer p {
   margin-bottom: 0.25rem;
-}
-
-.box-shadow {
-  box-shadow: 0 0.25rem 0.75rem rgba(0, 0, 0, 0.05);
-}
-
-.text {
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 
 .time {

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="345px" height="345px" viewBox="0 0 345 345" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <!-- Generator: Sketch 52.6 (67491) - http://www.bohemiancoding.com/sketch -->
+    <title>DT_Logo</title>
+    <desc>Created with Sketch.</desc>
+    <defs>
+        <circle id="path-1" cx="172.5" cy="172.5" r="172.5"></circle>
+    </defs>
+    <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g id="DT_Logo">
+            <mask id="mask-2" fill="white">
+                <use xlink:href="#path-1"></use>
+            </mask>
+            <circle stroke="#000000" stroke-width="12" cx="172.5" cy="172.5" r="166.5"></circle>
+            <path d="M327.168739,135.5 L343.274306,135.5" id="T-to-C" stroke="#F8F9FA" stroke-width="11" mask="url(#mask-2)"></path>
+            <path d="M1,195.5 L16.4756418,195.5" id="D-to-C" stroke="#F8F9FA" stroke-width="11" mask="url(#mask-2)"></path>
+            <g id="In" mask="url(#mask-2)" stroke="#2045D7" stroke-width="12">
+                <g transform="translate(-1.000000, 147.000000)">
+                    <path d="M0,60 L141,60 C157.568542,60 171,46.5685425 171,30 C171,13.4314575 157.568542,0 141,0 L106,0 L106,43" id="D"></path>
+                    <polyline id="T" points="181 0 216 0 216 65 216 0 349 0"></polyline>
+                </g>
+            </g>
+        </g>
+    </g>
+</svg>


### PR DESCRIPTION
Changed nav brand style
Add logo in the centre.
Logo hides when using a small screen.
Styled standard pages, to use the same header and footer.